### PR TITLE
1、改造为动态库 2、修复widgetHasVisibleArea内部逻辑

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,8 @@ else()
     unset(BUILD_SHARED_LIBS)
 endif()
 
-add_library(QtFluentWidgets
+add_library(QtFluentWidgets SHARED
+    include/Fluent/FluentExport.h
     include/Fluent/FluentAnimatedButton.h
     include/Fluent/FluentAnimatedIcon.h
     include/Fluent/FluentAutoSuggestBox.h
@@ -198,6 +199,7 @@ add_library(QtFluentWidgets
 )
 
 target_include_directories(QtFluentWidgets PUBLIC include)
+target_compile_definitions(QtFluentWidgets PRIVATE FLUENT_BUILDING_LIBRARY)
 target_link_libraries(QtFluentWidgets PUBLIC ${QT_PACKAGE}::Widgets ${QT_PACKAGE}::Svg rlottie::rlottie)
 if(MSVC)
     target_compile_options(QtFluentWidgets PRIVATE /utf-8)
@@ -253,6 +255,7 @@ target_compile_definitions(QtFluentDemo
 if(WIN32)
     add_custom_command(TARGET QtFluentDemo POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:rlottie> $<TARGET_FILE_DIR:QtFluentDemo>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QtFluentWidgets> $<TARGET_FILE_DIR:QtFluentDemo>
         VERBATIM
     )
 endif()
@@ -285,6 +288,7 @@ if(FLUENT_BUILD_TESTS)
     if(WIN32)
         add_custom_command(TARGET QtFluentWidgetsDesignerCompatTest POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:rlottie> $<TARGET_FILE_DIR:QtFluentWidgetsDesignerCompatTest>
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QtFluentWidgets> $<TARGET_FILE_DIR:QtFluentWidgetsDesignerCompatTest>
             VERBATIM
         )
         if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
@@ -330,6 +334,7 @@ if(FLUENT_BUILD_TESTS)
     if(WIN32)
         add_custom_command(TARGET QtFluentWidgetsVisualSmokeTest POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:rlottie> $<TARGET_FILE_DIR:QtFluentWidgetsVisualSmokeTest>
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QtFluentWidgets> $<TARGET_FILE_DIR:QtFluentWidgetsVisualSmokeTest>
             VERBATIM
         )
         if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.22)
@@ -473,6 +478,7 @@ if(FLUENT_BUILD_DESIGNER_PLUGIN)
     if(WIN32)
         add_custom_command(TARGET QtFluentWidgetsPlugin POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:rlottie> $<TARGET_FILE_DIR:QtFluentWidgetsPlugin>
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:QtFluentWidgets> $<TARGET_FILE_DIR:QtFluentWidgetsPlugin>
             VERBATIM
         )
     endif()

--- a/include/Fluent/FluentAccentBorderTrace.h
+++ b/include/Fluent/FluentAccentBorderTrace.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentStyle.h"
 #include "Fluent/FluentTheme.h"
 
@@ -18,7 +19,7 @@ namespace Fluent {
 // - No Q_OBJECT / moc required
 // - Owns its internal QVariantAnimation
 // - Exposes (from/to enabled, t) so callers can decide actual colors
-class FluentAccentBorderTrace final : public QObject
+class FLUENT_EXPORT FluentAccentBorderTrace final : public QObject
 {
 public:
     explicit FluentAccentBorderTrace(QWidget *updateTarget, QObject *parent = nullptr)

--- a/include/Fluent/FluentAngleSelector.h
+++ b/include/Fluent/FluentAngleSelector.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QWidget>
 
 class QString;
@@ -10,7 +12,7 @@ class FluentDial;
 class FluentSpinBox;
 class FluentLabel;
 
-class FluentAngleSelector final : public QWidget
+class FLUENT_EXPORT FluentAngleSelector final : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(int value READ value WRITE setValue NOTIFY valueChanged USER true)
@@ -66,4 +68,3 @@ private:
 };
 
 } // namespace Fluent
-

--- a/include/Fluent/FluentAnimatedButton.h
+++ b/include/Fluent/FluentAnimatedButton.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Fluent/FluentAnimatedIcon.h"
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentQtCompat.h"
 
 #include <QByteArray>
@@ -13,7 +14,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentAnimatedButton final : public QPushButton
+class FLUENT_EXPORT FluentAnimatedButton final : public QPushButton
 {
     Q_OBJECT
     Q_PROPERTY(bool primary READ isPrimary WRITE setPrimary)

--- a/include/Fluent/FluentAnimatedIcon.h
+++ b/include/Fluent/FluentAnimatedIcon.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentLottieWidget.h"
 #include "Fluent/FluentQtCompat.h"
 
@@ -7,7 +8,7 @@ class QMouseEvent;
 
 namespace Fluent {
 
-class FluentAnimatedIcon final : public FluentLottieWidget
+class FLUENT_EXPORT FluentAnimatedIcon final : public FluentLottieWidget
 {
     Q_OBJECT
     Q_PROPERTY(QString state READ state WRITE setState NOTIFY stateChanged)

--- a/include/Fluent/FluentAnnotatedScrollBar.h
+++ b/include/Fluent/FluentAnnotatedScrollBar.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QPointer>
 #include <QString>
 #include <QStringList>
@@ -34,7 +36,7 @@ inline bool operator==(const FluentAnnotatedScrollBarSource &lhs, const FluentAn
     return lhs.group == rhs.group && lhs.text == rhs.text && lhs.start == rhs.start && lhs.end == rhs.end;
 }
 
-class FluentAnnotatedScrollBar final : public QWidget
+class FLUENT_EXPORT FluentAnnotatedScrollBar final : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(bool showToolTipOnScroll READ showToolTipOnScroll WRITE setShowToolTipOnScroll)

--- a/include/Fluent/FluentAutoSuggestBox.h
+++ b/include/Fluent/FluentAutoSuggestBox.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QStringList>
 #include <QWidget>
 
@@ -11,7 +13,7 @@ class FluentAutoSuggestPopup;
 class FluentLineEdit;
 class FluentToolButton;
 
-class FluentAutoSuggestBox : public QWidget
+class FLUENT_EXPORT FluentAutoSuggestBox : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(QString text READ text WRITE setText NOTIFY textChanged)
@@ -66,7 +68,7 @@ private:
     QStringList m_suggestions;
 };
 
-class FluentSearchBox final : public FluentAutoSuggestBox
+class FLUENT_EXPORT FluentSearchBox final : public FluentAutoSuggestBox
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentBorderEffect.h
+++ b/include/Fluent/FluentBorderEffect.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentAccentBorderTrace.h"
 #include "Fluent/FluentFramePainter.h"
 #include "Fluent/FluentTheme.h"
@@ -29,7 +30,7 @@ namespace Fluent {
 //       paintFluentFrame(p, rect(), ThemeManager::instance().colors(), frame);
 //     }
 //   };
-class FluentBorderEffect final
+class FLUENT_EXPORT FluentBorderEffect final
 {
 public:
     explicit FluentBorderEffect(QWidget *updateTarget, QObject *parent = nullptr)

--- a/include/Fluent/FluentButton.h
+++ b/include/Fluent/FluentButton.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QPushButton>
 #include "Fluent/FluentQtCompat.h"
 
@@ -8,7 +10,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentButton : public QPushButton
+class FLUENT_EXPORT FluentButton : public QPushButton
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentCalendarPicker.h
+++ b/include/Fluent/FluentCalendarPicker.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QDateEdit>
 #include <QString>
 #include "Fluent/FluentQtCompat.h"
@@ -14,7 +16,7 @@ namespace Fluent {
 
 class FluentCalendarPopup;
 
-class FluentCalendarPicker final : public QDateEdit
+class FLUENT_EXPORT FluentCalendarPicker final : public QDateEdit
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentCard.h
+++ b/include/Fluent/FluentCard.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentQtCompat.h"
 
 #include <QByteArray>
@@ -14,7 +15,7 @@ namespace Fluent {
 
 class FluentCardContentClip;
 
-class FluentCard final : public QWidget
+class FLUENT_EXPORT FluentCard final : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(bool collapsible READ isCollapsible WRITE setCollapsible)

--- a/include/Fluent/FluentCheckBox.h
+++ b/include/Fluent/FluentCheckBox.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QCheckBox>
 #include "Fluent/FluentQtCompat.h"
 
@@ -9,7 +11,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentCheckBox final : public QCheckBox
+class FLUENT_EXPORT FluentCheckBox final : public QCheckBox
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentCodeEditor.h
+++ b/include/Fluent/FluentCodeEditor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QPlainTextEdit>
 #include "Fluent/FluentQtCompat.h"
 
@@ -14,7 +16,7 @@ class FluentCppHighlighter;
 class FluentCodeEditorLineNumberArea;
 class FluentCodeEditorBorderOverlay;
 
-class FluentCodeEditor : public QPlainTextEdit
+class FLUENT_EXPORT FluentCodeEditor : public QPlainTextEdit
 {
     Q_OBJECT
     Q_PROPERTY(QString clangFormatPath READ clangFormatPath WRITE setClangFormatPath)

--- a/include/Fluent/FluentColorDialog.h
+++ b/include/Fluent/FluentColorDialog.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QDialog>
 #include <QColor>
 #include <QPoint>
@@ -29,7 +31,7 @@ struct FluentGradientResult {
     int                      angle = 0;   // degrees, 0=left→right (LinearGradient only)
 };
 
-class FluentColorDialog final : public QDialog
+class FLUENT_EXPORT FluentColorDialog final : public QDialog
 {
     Q_OBJECT
 public:
@@ -98,5 +100,3 @@ private:
 };
 
 } // namespace Fluent
-
-

--- a/include/Fluent/FluentColorPicker.h
+++ b/include/Fluent/FluentColorPicker.h
@@ -1,14 +1,15 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QWidget>
-#include <QColor>
 
 class QLineEdit;
 class QPushButton;
 
 namespace Fluent {
 
-class FluentColorPicker final : public QWidget
+class FLUENT_EXPORT FluentColorPicker final : public QWidget
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentComboBox.h
+++ b/include/Fluent/FluentComboBox.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QComboBox>
 #include "Fluent/FluentQtCompat.h"
 
@@ -9,7 +11,7 @@ namespace Fluent {
 
 class FluentComboPopup;
 
-class FluentComboBox final : public QComboBox
+class FLUENT_EXPORT FluentComboBox final : public QComboBox
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentCommandBar.h
+++ b/include/Fluent/FluentCommandBar.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QHash>
 #include <QPointer>
 #include <QSet>
@@ -15,7 +17,7 @@ namespace Fluent {
 class FluentMenu;
 class FluentToolButton;
 
-class FluentCommandBar final : public QWidget
+class FLUENT_EXPORT FluentCommandBar final : public QWidget
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentCppHighlighter.h
+++ b/include/Fluent/FluentCppHighlighter.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QSyntaxHighlighter>
 #include <QRegularExpression>
 #include <QTextCharFormat>
@@ -9,7 +11,7 @@ class QTextDocument;
 
 namespace Fluent {
 
-class FluentCppHighlighter final : public QSyntaxHighlighter
+class FLUENT_EXPORT FluentCppHighlighter final : public QSyntaxHighlighter
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentDatePicker.h
+++ b/include/Fluent/FluentDatePicker.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QDate>
 #include <QFlags>
 #include <QString>
@@ -16,7 +18,7 @@ namespace Detail {
 class FluentWheelPickerPopup;
 }
 
-class FluentDatePicker final : public QWidget
+class FLUENT_EXPORT FluentDatePicker final : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentDateRangePicker.h
+++ b/include/Fluent/FluentDateRangePicker.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QDate>
 #include "Fluent/FluentQtCompat.h"
 #include <QString>
@@ -20,7 +22,7 @@ class FluentCalendarPopup;
 ///
 /// All text pieces are configurable; defaults produce:   yyyy-MM-dd  →  yyyy-MM-dd
 ///
-class FluentDateRangePicker final : public QWidget
+class FLUENT_EXPORT FluentDateRangePicker final : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)
@@ -118,4 +120,3 @@ private:
 };
 
 } // namespace Fluent
-

--- a/include/Fluent/FluentDiagnostics.h
+++ b/include/Fluent/FluentDiagnostics.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 namespace Fluent {
 
-class Diagnostics final
+class FLUENT_EXPORT Diagnostics final
 {
 public:
     Diagnostics() = delete;

--- a/include/Fluent/FluentDial.h
+++ b/include/Fluent/FluentDial.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QWidget>
 #include "Fluent/FluentQtCompat.h"
 
@@ -19,7 +21,7 @@ namespace Fluent {
  * values increase clockwise (same as Qt / CSS coordinate system).
  * The filled arc visualises the current angle from the 3-o'clock position.
  */
-class FluentDial final : public QWidget
+class FLUENT_EXPORT FluentDial final : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(int value READ value WRITE setValue NOTIFY valueChanged USER true)
@@ -88,4 +90,3 @@ private:
 };
 
 } // namespace Fluent
-

--- a/include/Fluent/FluentDialog.h
+++ b/include/Fluent/FluentDialog.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QDialog>
 #include <QPointer>
 
@@ -18,7 +20,7 @@ namespace Fluent {
 class FluentResizeHelper;
 class FluentToolButton;
 
-class FluentDialog : public QDialog
+class FLUENT_EXPORT FluentDialog : public QDialog
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentDropDownButton.h
+++ b/include/Fluent/FluentDropDownButton.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentButton.h"
 
 #include <QPointer>
@@ -10,7 +11,7 @@ class QMenu;
 
 namespace Fluent {
 
-class FluentDropDownButton : public FluentButton
+class FLUENT_EXPORT FluentDropDownButton : public FluentButton
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentExport.h
+++ b/include/Fluent/FluentExport.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <QtGlobal>
+
+#if defined(FLUENT_BUILDING_LIBRARY)
+#  define FLUENT_EXPORT Q_DECL_EXPORT
+#else
+#  define FLUENT_EXPORT Q_DECL_IMPORT
+#endif

--- a/include/Fluent/FluentFlowLayout.h
+++ b/include/Fluent/FluentFlowLayout.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QEasingCurve>
 #include <QLayout>
 #include <QStyle>
@@ -13,7 +15,7 @@ class QElapsedTimer;
 
 namespace Fluent {
 
-class FluentFlowLayout final : public QLayout
+class FLUENT_EXPORT FluentFlowLayout final : public QLayout
 {
 public:
     explicit FluentFlowLayout(QWidget *parent = nullptr, int margin = 0, int hSpacing = 12, int vSpacing = 12);

--- a/include/Fluent/FluentFlyout.h
+++ b/include/Fluent/FluentFlyout.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentBorderEffect.h"
 
 #include <QMargins>
@@ -11,7 +12,7 @@ class QVBoxLayout;
 
 namespace Fluent {
 
-class FluentFlyout : public QWidget
+class FLUENT_EXPORT FluentFlyout : public QWidget
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentFramePainter.h
+++ b/include/Fluent/FluentFramePainter.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentStyle.h"
 #include "Fluent/FluentTheme.h"
 

--- a/include/Fluent/FluentGroupBox.h
+++ b/include/Fluent/FluentGroupBox.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QGroupBox>
 #include <QRect>
 
 namespace Fluent {
 
-class FluentGroupBox final : public QGroupBox
+class FLUENT_EXPORT FluentGroupBox final : public QGroupBox
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentIcon.h
+++ b/include/Fluent/FluentIcon.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QColor>
 #include <QIcon>
 #include <QRectF>
@@ -72,7 +74,7 @@ struct FluentIconOptions {
     qreal opacity = 1.0;
 };
 
-class FluentIcon final
+class FLUENT_EXPORT FluentIcon final
 {
 public:
     explicit FluentIcon(FluentIconType type = FluentIconType::Info);

--- a/include/Fluent/FluentIconButton.h
+++ b/include/Fluent/FluentIconButton.h
@@ -1,12 +1,14 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QIcon>
 
 #include "Fluent/FluentButton.h"
 
 namespace Fluent {
 
-class FluentIconButton final : public FluentButton
+class FLUENT_EXPORT FluentIconButton final : public FluentButton
 {
     Q_OBJECT
     Q_PROPERTY(int buttonExtent READ buttonExtent WRITE setButtonExtent)

--- a/include/Fluent/FluentInfoBar.h
+++ b/include/Fluent/FluentInfoBar.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QWidget>
 
 class QHBoxLayout;
@@ -14,7 +16,7 @@ class FluentButton;
 class FluentLabel;
 class FluentToolButton;
 
-class FluentInfoBar final : public QWidget
+class FLUENT_EXPORT FluentInfoBar final : public QWidget
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentKeySequenceEdit.h
+++ b/include/Fluent/FluentKeySequenceEdit.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QKeySequenceEdit>
 #include <QPointer>
 
@@ -11,7 +13,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentKeySequenceEdit final : public QKeySequenceEdit
+class FLUENT_EXPORT FluentKeySequenceEdit final : public QKeySequenceEdit
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentLabel.h
+++ b/include/Fluent/FluentLabel.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QLabel>
 
 namespace Fluent {
 
-class FluentLabel final : public QLabel
+class FLUENT_EXPORT FluentLabel final : public QLabel
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentLineEdit.h
+++ b/include/Fluent/FluentLineEdit.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QLineEdit>
 #include "Fluent/FluentQtCompat.h"
 
@@ -9,7 +11,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentLineEdit final : public QLineEdit
+class FLUENT_EXPORT FluentLineEdit final : public QLineEdit
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentListView.h
+++ b/include/Fluent/FluentListView.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QListView>
 #include <QMetaObject>
 
@@ -10,7 +12,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentListView final : public QListView
+class FLUENT_EXPORT FluentListView final : public QListView
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentLottieWidget.h
+++ b/include/Fluent/FluentLottieWidget.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QByteArray>
 #include <QColor>
 #include <QIcon>
@@ -12,7 +14,7 @@
 
 namespace Fluent {
 
-class FluentLottieWidget : public QWidget
+class FLUENT_EXPORT FluentLottieWidget : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(QString source READ source WRITE setSource NOTIFY sourceChanged)

--- a/include/Fluent/FluentMainWindow.h
+++ b/include/Fluent/FluentMainWindow.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QIcon>
 #include <QMainWindow>
 #include <QPointer>
@@ -19,7 +21,7 @@ namespace Fluent { class FluentMenuBar; class FluentToolButton; class FluentResi
 
 namespace Fluent {
 
-class FluentMainWindow : public QMainWindow
+class FLUENT_EXPORT FluentMainWindow : public QMainWindow
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentMenu.h
+++ b/include/Fluent/FluentMenu.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QMenu>
 
 #include <QPointer>
@@ -17,7 +19,7 @@ class QResizeEvent;
 
 namespace Fluent {
 
-class FluentMenu final : public QMenu
+class FLUENT_EXPORT FluentMenu final : public QMenu
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentMenuBar.h
+++ b/include/Fluent/FluentMenuBar.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QMenuBar>
 
 #include <QHash>
@@ -19,7 +21,7 @@ class QWidget;
 
 namespace Fluent {
 
-class FluentMenuBar final : public QMenuBar
+class FLUENT_EXPORT FluentMenuBar final : public QMenuBar
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentMessageBox.h
+++ b/include/Fluent/FluentMessageBox.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QDialog>
 #include <QPointer>
 #include <QUrl>
@@ -13,7 +15,7 @@ class QHideEvent;
 
 namespace Fluent {
 
-class FluentMessageBox final : public QDialog
+class FLUENT_EXPORT FluentMessageBox final : public QDialog
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentMotion.h
+++ b/include/Fluent/FluentMotion.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentTheme.h"
 
 #include <QEasingCurve>

--- a/include/Fluent/FluentNavigationView.h
+++ b/include/Fluent/FluentNavigationView.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentIcon.h"
 #include "Fluent/FluentQtCompat.h"
 
@@ -45,7 +46,7 @@ struct FluentNavigationItem
 // FluentNavigationView – hierarchical navigation sidebar
 // ---------------------------------------------------------------------------
 
-class FluentNavigationView : public QWidget
+class FLUENT_EXPORT FluentNavigationView : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(int expandedWidth READ expandedWidth WRITE setExpandedWidth)

--- a/include/Fluent/FluentPopupSurface.h
+++ b/include/Fluent/FluentPopupSurface.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentBorderEffect.h"
 #include "Fluent/FluentFramePainter.h"
 #include "Fluent/FluentStyle.h"
@@ -178,4 +179,3 @@ inline void paintPanelWithShadowMargins(QPainter &painter, const QRect &rect,
 
 } // namespace PopupSurface
 } // namespace Fluent
-

--- a/include/Fluent/FluentProgressBar.h
+++ b/include/Fluent/FluentProgressBar.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QColor>
 #include <QProgressBar>
 
@@ -7,7 +9,7 @@ class QPropertyAnimation;
 
 namespace Fluent {
 
-class FluentProgressBar final : public QProgressBar
+class FLUENT_EXPORT FluentProgressBar final : public QProgressBar
 {
     Q_OBJECT
     Q_PROPERTY(qreal displayValue READ displayValue WRITE setDisplayValue)

--- a/include/Fluent/FluentProgressRing.h
+++ b/include/Fluent/FluentProgressRing.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QBasicTimer>
 #include <QProgressBar>
 
@@ -7,7 +9,7 @@ class QPropertyAnimation;
 
 namespace Fluent {
 
-class FluentProgressRing final : public QProgressBar
+class FLUENT_EXPORT FluentProgressRing final : public QProgressBar
 {
     Q_OBJECT
     Q_PROPERTY(qreal displayValue READ displayValue WRITE setDisplayValue)

--- a/include/Fluent/FluentRadioButton.h
+++ b/include/Fluent/FluentRadioButton.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QRadioButton>
 #include "Fluent/FluentQtCompat.h"
 
@@ -8,7 +10,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentRadioButton final : public QRadioButton
+class FLUENT_EXPORT FluentRadioButton final : public QRadioButton
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentResizeHelper.h
+++ b/include/Fluent/FluentResizeHelper.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QObject>
 #include <QPoint>
 #include <QRect>
@@ -11,7 +13,7 @@ class QMouseEvent;
 
 namespace Fluent {
 
-class FluentResizeHelper final : public QObject
+class FLUENT_EXPORT FluentResizeHelper final : public QObject
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentScrollArea.h
+++ b/include/Fluent/FluentScrollArea.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QScrollArea>
 
 class QEvent;
@@ -9,7 +11,7 @@ namespace Fluent {
 
 class FluentScrollBar;
 
-class FluentScrollArea : public QScrollArea
+class FLUENT_EXPORT FluentScrollArea : public QScrollArea
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentScrollBar.h
+++ b/include/Fluent/FluentScrollBar.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QScrollBar>
 #include "Fluent/FluentQtCompat.h"
 
@@ -10,7 +12,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentScrollBar final : public QScrollBar
+class FLUENT_EXPORT FluentScrollBar final : public QScrollBar
 {
     Q_OBJECT
     Q_PROPERTY(qreal revealLevel READ revealLevel WRITE setRevealLevel)

--- a/include/Fluent/FluentSlider.h
+++ b/include/Fluent/FluentSlider.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QSlider>
 #include "Fluent/FluentQtCompat.h"
 
@@ -7,7 +9,7 @@ class QPropertyAnimation;
 
 namespace Fluent {
 
-class FluentSlider final : public QSlider
+class FLUENT_EXPORT FluentSlider final : public QSlider
 {
     Q_OBJECT
     Q_PROPERTY(qreal handlePos READ handlePos WRITE setHandlePos)

--- a/include/Fluent/FluentSpinBox.h
+++ b/include/Fluent/FluentSpinBox.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QSpinBox>
 #include "Fluent/FluentQtCompat.h"
 #include <QVariantAnimation>
@@ -10,7 +12,7 @@ class QLineEdit;
 
 namespace Fluent {
 
-class FluentSpinBox final : public QSpinBox
+class FLUENT_EXPORT FluentSpinBox final : public QSpinBox
 {
     Q_OBJECT
 public:
@@ -58,7 +60,7 @@ private:
     QLineEdit *m_editor = nullptr;
 };
 
-class FluentDoubleSpinBox final : public QDoubleSpinBox
+class FLUENT_EXPORT FluentDoubleSpinBox final : public QDoubleSpinBox
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentSplitButton.h
+++ b/include/Fluent/FluentSplitButton.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QPointer>
 #include <QWidget>
 
@@ -11,7 +13,7 @@ namespace Fluent {
 
 class FluentButton;
 
-class FluentSplitButton final : public QWidget
+class FLUENT_EXPORT FluentSplitButton final : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(QString text READ text WRITE setText)

--- a/include/Fluent/FluentSplitter.h
+++ b/include/Fluent/FluentSplitter.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QSplitter>
 
 namespace Fluent {
 
-class FluentSplitter final : public QSplitter
+class FLUENT_EXPORT FluentSplitter final : public QSplitter
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentStatusBar.h
+++ b/include/Fluent/FluentStatusBar.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QStatusBar>
 
 namespace Fluent {
 
-class FluentStatusBar final : public QStatusBar
+class FLUENT_EXPORT FluentStatusBar final : public QStatusBar
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentStyle.h
+++ b/include/Fluent/FluentStyle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentTheme.h"
 
 #include <QColor>
@@ -36,7 +37,7 @@ struct WindowMetrics {
     QEasingCurve::Type accentBorderTraceDisableEasing = QEasingCurve::InCubic;
 };
 
-class Style final
+class FLUENT_EXPORT Style final
 {
 public:
     static ControlMetrics metrics();

--- a/include/Fluent/FluentTabWidget.h
+++ b/include/Fluent/FluentTabWidget.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QTabWidget>
 
 namespace Fluent {
 
-class FluentTabWidget final : public QTabWidget
+class FLUENT_EXPORT FluentTabWidget final : public QTabWidget
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentTableView.h
+++ b/include/Fluent/FluentTableView.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QMetaObject>
 #include <QTableView>
 
@@ -10,7 +12,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentTableView final : public QTableView
+class FLUENT_EXPORT FluentTableView final : public QTableView
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentTableWidget.h
+++ b/include/Fluent/FluentTableWidget.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QMetaObject>
 #include <QTableWidget>
 
@@ -10,7 +12,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentTableWidget final : public QTableWidget
+class FLUENT_EXPORT FluentTableWidget final : public QTableWidget
 {
     Q_OBJECT
 public:
@@ -51,5 +53,3 @@ private:
 };
 
 } // namespace Fluent
-
-

--- a/include/Fluent/FluentTeachingTip.h
+++ b/include/Fluent/FluentTeachingTip.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentFlyout.h"
 
 #include <QList>
@@ -17,7 +18,7 @@ class FluentButton;
 class FluentLabel;
 class FluentToolButton;
 
-class FluentTeachingTip final : public FluentFlyout
+class FLUENT_EXPORT FluentTeachingTip final : public FluentFlyout
 {
     Q_OBJECT
     Q_PROPERTY(QString title READ title WRITE setTitle)

--- a/include/Fluent/FluentTextEdit.h
+++ b/include/Fluent/FluentTextEdit.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QTextEdit>
 #include "Fluent/FluentQtCompat.h"
 
@@ -12,7 +14,7 @@ class QWidget;
 
 namespace Fluent {
 
-class FluentTextEdit final : public QTextEdit
+class FLUENT_EXPORT FluentTextEdit final : public QTextEdit
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentTheme.h
+++ b/include/Fluent/FluentTheme.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QObject>
 #include <QColor>
 #include <QList>
@@ -127,7 +129,7 @@ struct FluentThemeTokens {
     bool dark = false;
 };
 
-class Theme final
+class FLUENT_EXPORT Theme final
 {
 public:
     static ThemeColors light();
@@ -166,7 +168,7 @@ public:
     static QString cardStyle(const ThemeColors &colors);
 };
 
-class ThemeManager final : public QObject
+class FLUENT_EXPORT ThemeManager final : public QObject
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentTimePicker.h
+++ b/include/Fluent/FluentTimePicker.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QString>
 #include <QTimeEdit>
 
@@ -17,7 +19,7 @@ namespace Detail {
 class FluentWheelPickerPopup;
 }
 
-class FluentTimePicker final : public QTimeEdit
+class FLUENT_EXPORT FluentTimePicker final : public QTimeEdit
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentToast.h
+++ b/include/Fluent/FluentToast.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QWidget>
 
 #include "Fluent/FluentBorderEffect.h"
@@ -10,7 +12,7 @@ class QMouseEvent;
 
 namespace Fluent {
 
-class FluentToast final : public QWidget
+class FLUENT_EXPORT FluentToast final : public QWidget
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentToggleSwitch.h
+++ b/include/Fluent/FluentToggleSwitch.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QWidget>
 #include "Fluent/FluentQtCompat.h"
 
@@ -7,7 +9,7 @@ class QPropertyAnimation;
 
 namespace Fluent {
 
-class FluentToggleSwitch final : public QWidget
+class FLUENT_EXPORT FluentToggleSwitch final : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY(qreal progress READ progress WRITE setProgress)

--- a/include/Fluent/FluentToolBar.h
+++ b/include/Fluent/FluentToolBar.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QHash>
 #include <QMetaObject>
 #include <QPointer>
@@ -11,7 +13,7 @@ class QWidgetAction;
 
 namespace Fluent {
 
-class FluentToolBar final : public QToolBar
+class FLUENT_EXPORT FluentToolBar final : public QToolBar
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentToolButton.h
+++ b/include/Fluent/FluentToolButton.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QToolButton>
 #include "Fluent/FluentQtCompat.h"
 
@@ -8,7 +10,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentToolButton final : public QToolButton
+class FLUENT_EXPORT FluentToolButton final : public QToolButton
 {
     Q_OBJECT
     Q_PROPERTY(qreal hoverLevel READ hoverLevel WRITE setHoverLevel)

--- a/include/Fluent/FluentToolTip.h
+++ b/include/Fluent/FluentToolTip.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QPoint>
 #include <QString>
 
@@ -7,7 +9,7 @@ class QWidget;
 
 namespace Fluent {
 
-class FluentToolTip final
+class FLUENT_EXPORT FluentToolTip final
 {
 public:
     static void ensureInstalled();
@@ -16,4 +18,3 @@ public:
 };
 
 } // namespace Fluent
-

--- a/include/Fluent/FluentTreeView.h
+++ b/include/Fluent/FluentTreeView.h
@@ -1,5 +1,7 @@
 ﻿#pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QMetaObject>
 #include <QTreeView>
 
@@ -10,7 +12,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentTreeView final : public QTreeView
+class FLUENT_EXPORT FluentTreeView final : public QTreeView
 {
     Q_OBJECT
 public:

--- a/include/Fluent/FluentWidget.h
+++ b/include/Fluent/FluentWidget.h
@@ -1,12 +1,14 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
+
 #include <QWidget>
 
 class QPaintEvent;
 
 namespace Fluent {
 
-class FluentWidget : public QWidget
+class FLUENT_EXPORT FluentWidget : public QWidget
 {
     Q_OBJECT
 public:

--- a/include/Fluent/datePicker/FluentCalendarPopup.h
+++ b/include/Fluent/datePicker/FluentCalendarPopup.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Fluent/FluentExport.h"
 #include "Fluent/FluentBorderEffect.h"
 
 #include <QDate>
@@ -13,7 +14,7 @@ class QVariantAnimation;
 
 namespace Fluent {
 
-class FluentCalendarPopup final : public QWidget
+class FLUENT_EXPORT FluentCalendarPopup final : public QWidget
 {
 	Q_OBJECT
 public:
@@ -170,4 +171,3 @@ private:
 };
 
 } // namespace Fluent
-

--- a/src/FluentLottieWidget.cpp
+++ b/src/FluentLottieWidget.cpp
@@ -129,6 +129,7 @@ bool widgetHasVisibleArea(const QWidget *widget)
 
     const QWidget *current = widget;
     while (const QWidget *parent = current->parentWidget()) {
+        if (parent->isWindow()) break;
         if (parent->isHidden() || !parent->isVisible()) {
             return false;
         }

--- a/src/FluentProgressRing.cpp
+++ b/src/FluentProgressRing.cpp
@@ -38,6 +38,7 @@ bool widgetHasVisibleArea(const QWidget *widget)
 
     const QWidget *current = widget;
     while (const QWidget *parent = current->parentWidget()) {
+        if (parent->isWindow()) break;
         if (parent->isHidden() || !parent->isVisible()) {
             return false;
         }


### PR DESCRIPTION
1、改造为动态库，解决静态局部单例变量在静态库的引用方式下会有多副本的问题（调用者在多个dll模块中调用）
2、修复widgetHasVisibleArea内部逻辑如果是独立的dialog的情况下判断逻辑不对的问题，会导致界面刷新停滞部分动态效果无法更新